### PR TITLE
V1: canonical integration + portable paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+data/
+out/
+__pycache__/
+*.pyc

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,0 +1,3 @@
+from .base import SourceAdapter, LicenseRow
+from .seeds_adapter import SeedsAdapter
+from .registry import build_adapters

--- a/adapters/registry.py
+++ b/adapters/registry.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .base import SourceAdapter
+from .seeds_adapter import SeedsAdapter
+
+
+def build_adapters(base_dir: Path) -> List[SourceAdapter]:
+    """Return enabled source adapters for ingestion.
+
+    V1 default: local seeds CSV adapter.
+    Additional adapters can be appended here as they are implemented.
+    """
+    seed_file = base_dir / 'seeds.csv'
+    adapters: List[SourceAdapter] = []
+    if seed_file.exists():
+        adapters.append(SeedsAdapter(str(seed_file)))
+    return adapters

--- a/brief.py
+++ b/brief.py
@@ -3,7 +3,7 @@ import csv
 from pathlib import Path
 from datetime import datetime
 
-BASE = Path('/Users/lunavanamburg/.openclaw/workspace/leads_engine')
+BASE = Path(__file__).resolve().parent
 PRIMARY = BASE / 'out/outreach_dispensary_100.csv'
 SECONDARY = BASE / 'out/enriched_leads.csv'
 FALLBACK = BASE / 'out/verified_leads.csv'

--- a/crawler.py
+++ b/crawler.py
@@ -5,7 +5,7 @@ from urllib.request import Request, urlopen
 from pathlib import Path
 from datetime import datetime
 
-BASE = Path('/Users/lunavanamburg/.openclaw/workspace/leads_engine')
+BASE = Path(__file__).resolve().parent
 SEEDS = BASE / 'seeds.csv'
 DB = BASE / 'data/leads.db'
 OUT = BASE / 'out/verified_leads.csv'

--- a/crawler_v2.py
+++ b/crawler_v2.py
@@ -8,7 +8,7 @@ from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 from urllib import robotparser
 
-BASE = Path('/Users/lunavanamburg/.openclaw/workspace/leads_engine')
+BASE = Path(__file__).resolve().parent
 CFG_PATH = BASE / 'crawler_config.json'
 SEEDS_PATH = BASE / 'seeds.csv'
 DB_PATH = BASE / 'data/leads_v2.db'

--- a/enrich.py
+++ b/enrich.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from urllib.request import Request, urlopen
 from urllib.parse import urlparse
 
-BASE = Path('/Users/lunavanamburg/.openclaw/workspace/leads_engine')
+BASE = Path(__file__).resolve().parent
 OUT = BASE / 'out'
 RAW = OUT / 'raw_leads.csv'
 DB = BASE / 'data/leads_v2.db'

--- a/jobs/ingest_sources.py
+++ b/jobs/ingest_sources.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import hashlib
 import sqlite3
+import uuid
 from datetime import datetime
 from pathlib import Path
-import uuid
+from urllib.parse import urlparse
 
-from adapters.seeds_adapter import SeedsAdapter
+from adapters.registry import build_adapters
+from adapters.base import LicenseRow
 
-BASE = Path('/Users/lunavanamburg/.openclaw/workspace/leads_engine')
+BASE = Path(__file__).resolve().parents[1]
 DB = BASE / 'data/cannaradar_v1.db'
 SCHEMA = BASE / 'db/schema.sql'
-SEEDS = BASE / 'seeds.csv'
 
 
 def make_pk(prefix: str, parts: list[str]) -> str:
@@ -20,55 +22,89 @@ def make_pk(prefix: str, parts: list[str]) -> str:
     return f"{prefix}_{h}"
 
 
+def normalized_domain(url_or_domain: str) -> str:
+    v = (url_or_domain or '').strip()
+    if not v:
+        return ''
+    if '://' not in v:
+        v = f'https://{v}'
+    try:
+        host = (urlparse(v).netloc or '').lower()
+        if host.startswith('www.'):
+            host = host[4:]
+        return host
+    except Exception:
+        return ''
+
+
 def init_db(con: sqlite3.Connection):
     con.executescript(SCHEMA.read_text())
     con.commit()
 
 
-def upsert_from_seed(con: sqlite3.Connection):
-    adapter = SeedsAdapter(str(SEEDS))
-    raw = adapter.fetch_raw()
-    rows = adapter.normalize_rows(adapter.parse_raw_to_rows(raw))
+def upsert_row(con: sqlite3.Connection, r: LicenseRow, now: str):
+    domain = normalized_domain(r.website)
+    org_pk = make_pk('org', [r.legal_name or r.dba_name, r.state])
+    # Dedupe baseline: location key uses domain + state first, then name fallback.
+    loc_pk = make_pk('loc', [domain or r.website, r.state, r.dba_name or r.legal_name])
+    lic_pk = make_pk('lic', [r.state, r.license_id or domain or r.website, r.legal_name or r.dba_name])
+
+    con.execute('''INSERT OR REPLACE INTO organizations (org_pk, legal_name, dba_name, state, created_at, updated_at)
+                   VALUES (?,?,?,?,COALESCE((SELECT created_at FROM organizations WHERE org_pk=?),?),?)''',
+                (org_pk, r.legal_name, r.dba_name, r.state, org_pk, now, now))
+
+    con.execute('''INSERT OR REPLACE INTO licenses (license_pk, org_pk, state, license_id, license_type, status, source_url, retrieved_at, fingerprint)
+                   VALUES (?,?,?,?,?,?,?,?,?)''',
+                (lic_pk, org_pk, r.state, r.license_id, r.license_type, r.status, r.source_url, r.retrieved_at, make_pk('fp',[r.legal_name,r.website,r.state])))
+
+    con.execute('''INSERT OR REPLACE INTO locations (location_pk, org_pk, canonical_name, address_1, city, state, zip, website_domain, phone, fit_score, last_crawled_at, created_at, updated_at)
+                   VALUES (?,?,?,?,?,?,?,?,?,0,NULL,COALESCE((SELECT created_at FROM locations WHERE location_pk=?),?),?)''',
+                (loc_pk, org_pk, r.dba_name or r.legal_name, r.address_1, r.city, r.state, r.zip, domain, r.phone, loc_pk, now, now))
+
+    if domain:
+        website_pk = make_pk('cp', [loc_pk, 'website', domain])
+        con.execute('''INSERT OR REPLACE INTO contact_points (contact_pk, location_pk, type, value, confidence, source_url, first_seen_at, last_seen_at)
+                       VALUES (?,?,?,?,?,?,COALESCE((SELECT first_seen_at FROM contact_points WHERE contact_pk=?),?),?)''',
+                    (website_pk, loc_pk, 'website', domain, 0.9, r.source_url or r.website, website_pk, now, now))
+
+    if r.phone:
+        phone_pk = make_pk('cp', [loc_pk, 'phone', r.phone])
+        con.execute('''INSERT OR REPLACE INTO contact_points (contact_pk, location_pk, type, value, confidence, source_url, first_seen_at, last_seen_at)
+                       VALUES (?,?,?,?,?,?,COALESCE((SELECT first_seen_at FROM contact_points WHERE contact_pk=?),?),?)''',
+                    (phone_pk, loc_pk, 'phone', r.phone, 0.8, r.source_url or r.website, phone_pk, now, now))
+
+    ev_pk = str(uuid.uuid4())
+    con.execute('''INSERT OR REPLACE INTO evidence (evidence_pk, entity_type, entity_pk, field_name, field_value, source_url, snippet, captured_at)
+                   VALUES (?,?,?,?,?,?,?,?)''',
+                (ev_pk, 'location', loc_pk, 'website_domain', domain, r.source_url, 'source ingestion', now))
+
+
+def ingest_all(con: sqlite3.Connection) -> int:
+    adapters = build_adapters(BASE)
+    if not adapters:
+        print('No adapters enabled. Nothing to ingest.')
+        return 0
+
+    total = 0
     now = datetime.now().isoformat(timespec='seconds')
-
-    for r in rows:
-        org_pk = make_pk('org', [r.legal_name, r.state])
-        loc_pk = make_pk('loc', [r.dba_name, r.website, r.state])
-        lic_pk = make_pk('lic', [r.state, r.license_id or r.website, r.legal_name])
-
-        con.execute('''INSERT OR REPLACE INTO organizations (org_pk, legal_name, dba_name, state, created_at, updated_at)
-                       VALUES (?,?,?,?,COALESCE((SELECT created_at FROM organizations WHERE org_pk=?),?),?)''',
-                    (org_pk, r.legal_name, r.dba_name, r.state, org_pk, now, now))
-
-        con.execute('''INSERT OR REPLACE INTO licenses (license_pk, org_pk, state, license_id, license_type, status, source_url, retrieved_at, fingerprint)
-                       VALUES (?,?,?,?,?,?,?,?,?)''',
-                    (lic_pk, org_pk, r.state, r.license_id, r.license_type, r.status, r.source_url, r.retrieved_at, make_pk('fp',[r.legal_name,r.website,r.state])))
-
-        con.execute('''INSERT OR REPLACE INTO locations (location_pk, org_pk, canonical_name, address_1, city, state, zip, website_domain, phone, fit_score, last_crawled_at, created_at, updated_at)
-                       VALUES (?,?,?,?,?,?,?,?,?,0,NULL,COALESCE((SELECT created_at FROM locations WHERE location_pk=?),?),?)''',
-                    (loc_pk, org_pk, r.dba_name or r.legal_name, r.address_1, r.city, r.state, r.zip, r.website, r.phone, loc_pk, now, now))
-
-        if r.website:
-            contact_pk = make_pk('cp', [loc_pk, 'website', r.website])
-            con.execute('''INSERT OR REPLACE INTO contact_points (contact_pk, location_pk, type, value, confidence, source_url, first_seen_at, last_seen_at)
-                           VALUES (?,?,?,?,?,?,COALESCE((SELECT first_seen_at FROM contact_points WHERE contact_pk=?),?),?)''',
-                        (contact_pk, loc_pk, 'website', r.website, 0.9, r.source_url or r.website, contact_pk, now, now))
-
-        ev_pk = str(uuid.uuid4())
-        con.execute('''INSERT OR REPLACE INTO evidence (evidence_pk, entity_type, entity_pk, field_name, field_value, source_url, snippet, captured_at)
-                       VALUES (?,?,?,?,?,?,?,?)''',
-                    (ev_pk, 'location', loc_pk, 'website_domain', r.website, r.source_url, 'seed ingestion', now))
+    for adapter in adapters:
+        raw = adapter.fetch_raw()
+        rows = adapter.normalize_rows(adapter.parse_raw_to_rows(raw))
+        for row in rows:
+            upsert_row(con, row, now)
+        total += len(rows)
+        print(f'Adapter {adapter.source_name}: ingested {len(rows)} rows')
 
     con.commit()
-    return len(rows)
+    return total
 
 
 def main():
     DB.parent.mkdir(parents=True, exist_ok=True)
     con = sqlite3.connect(DB)
     init_db(con)
-    n = upsert_from_seed(con)
-    print(f'Ingested {n} seed rows into canonical DB: {DB}')
+    n = ingest_all(con)
+    print(f'Ingested {n} total rows into canonical DB: {DB}')
 
 
 if __name__ == '__main__':

--- a/postprocess_v4.py
+++ b/postprocess_v4.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-import csv, re
+import csv
+import re
+import sqlite3
 from pathlib import Path
 from datetime import datetime
 
-BASE = Path('/Users/lunavanamburg/.openclaw/workspace/leads_engine')
+BASE = Path(__file__).resolve().parent
 OUT = BASE / 'out'
 IN_PRIMARY = OUT / 'enriched_leads.csv'
 IN_FALLBACK = OUT / 'raw_leads.csv'
+CANONICAL_DB = BASE / 'data/cannaradar_v1.db'
 
 # Segment rules
 STORE_POSITIVE = re.compile(r'\b(dispensary|cannabis|care station|the source|nuwu|lightshade|native roots|terrapin|flowery|stiiizy|mint|rise|sunnyside|zen leaf|verilife|muv|apothecarium|botanist|jardin|medizin)\b', re.I)
@@ -18,9 +21,12 @@ def score_adjust(base, segment, email, phone, owner):
     s = int(base or 0)
     if segment == 'dispensary':
         s += 15
-    if email: s += 5
-    if phone: s += 5
-    if owner: s += 5
+    if email:
+        s += 5
+    if phone:
+        s += 5
+    if owner:
+        s += 5
     return max(0, min(100, s))
 
 
@@ -35,24 +41,78 @@ def classify_segment(name, website, source_url):
 
 def clean_owner(name):
     n = (name or '').strip()
-    if not n: return ''
-    if JUNK_OWNER.search(n): return ''
-    # basic human-name heuristic: 2-3 capitalized words
+    if not n:
+        return ''
+    if JUNK_OWNER.search(n):
+        return ''
     parts = n.split()
-    if len(parts) < 2 or len(parts) > 3: return ''
-    if not all(p[:1].isupper() for p in parts): return ''
+    if len(parts) < 2 or len(parts) > 3:
+        return ''
+    if not all(p[:1].isupper() for p in parts):
+        return ''
     return n
 
 
-def read_rows():
+def read_pipeline_rows():
     src = IN_PRIMARY if IN_PRIMARY.exists() else IN_FALLBACK
     if not src.exists():
         return []
     return list(csv.DictReader(src.open()))
 
 
+def read_canonical_rows():
+    if not CANONICAL_DB.exists():
+        return []
+
+    con = sqlite3.connect(CANONICAL_DB)
+    rows = con.execute(
+        '''SELECT l.canonical_name, l.website_domain, l.state, l.phone,
+                  MAX(CASE WHEN cp.type='email' THEN cp.value ELSE '' END) as email,
+                  MAX(CASE WHEN cp.type='website' THEN cp.value ELSE '' END) as source_url
+           FROM locations l
+           LEFT JOIN contact_points cp ON cp.location_pk = l.location_pk
+           GROUP BY l.location_pk, l.canonical_name, l.website_domain, l.state, l.phone'''
+    ).fetchall()
+    con.close()
+
+    out = []
+    for name, website, state, phone, email, source_url in rows:
+        out.append({
+            'dispensary': name or '',
+            'website': website or '',
+            'state': state or '',
+            'market': '',
+            'owner_name': '',
+            'owner_role': '',
+            'email': email or '',
+            'phone': phone or '',
+            'source_url': source_url or website or '',
+            'score': '0',
+            'checked_at': '',
+        })
+    return out
+
+
+def dedupe_rows(rows):
+    seen = set()
+    out = []
+    for r in rows:
+        website = (r.get('website') or '').strip().lower().replace('https://', '').replace('http://', '').strip('/')
+        name = (r.get('dispensary') or r.get('name') or '').strip().lower()
+        state = (r.get('state') or '').strip().lower()
+        key = (website or name, state)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(r)
+    return out
+
+
 def main():
-    rows = read_rows()
+    pipeline_rows = read_pipeline_rows()
+    canonical_rows = read_canonical_rows()
+    rows = dedupe_rows(pipeline_rows + canonical_rows)
+
     now = datetime.now().isoformat(timespec='seconds')
     normalized = []
     for r in rows:
@@ -93,12 +153,19 @@ def main():
 
     fields = ['dispensary','segment','website','state','market','owner_name','owner_role','email','phone','source_url','score','checked_at']
 
+    OUT.mkdir(parents=True, exist_ok=True)
     with out_all.open('w', newline='') as f:
-        w = csv.DictWriter(f, fieldnames=fields); w.writeheader(); w.writerows(normalized)
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerows(normalized)
     with out_disp.open('w', newline='') as f:
-        w = csv.DictWriter(f, fieldnames=fields); w.writeheader(); w.writerows(dispensary[:100])
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerows(dispensary[:100])
     with out_non.open('w', newline='') as f:
-        w = csv.DictWriter(f, fieldnames=fields); w.writeheader(); w.writerows(non_disp)
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        w.writerows(non_disp)
 
     lines = []
     lines.append(f'V4 Quality Report ({now})')
@@ -108,6 +175,7 @@ def main():
     lines.append(f'Dispensary rows w/ email: {sum(1 for r in dispensary if r["email"])}')
     lines.append(f'Dispensary rows w/ phone: {sum(1 for r in dispensary if r["phone"])}')
     lines.append(f'Dispensary rows w/ cleaned owner: {sum(1 for r in dispensary if r["owner_name"])}')
+    lines.append(f'Canonical rows merged: {len(canonical_rows)}')
     lines.append('')
     lines.append('Top dispensary rows:')
     for r in dispensary[:15]:
@@ -115,6 +183,7 @@ def main():
 
     out_qa.write_text('\n'.join(lines) + '\n')
     print(f'Wrote {out_disp} ({len(dispensary[:100])} rows)')
+
 
 if __name__ == '__main__':
     main()

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-set -e
-cd /Users/lunavanamburg/.openclaw/workspace/leads_engine
+set -euo pipefail
+cd "$(dirname "$0")"
 ./crawler.py
 ./brief.py

--- a/run_v1_features.sh
+++ b/run_v1_features.sh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-set -e
-cd /Users/lunavanamburg/.openclaw/workspace/leads_engine
-PYTHONPATH=/Users/lunavanamburg/.openclaw/workspace/leads_engine python3 jobs/ingest_sources.py
+set -euo pipefail
+cd "$(dirname "$0")"
+PYTHONPATH="$PWD" python3 jobs/ingest_sources.py
 ./run_v4.sh

--- a/run_v2.sh
+++ b/run_v2.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
-set -e
-cd /Users/lunavanamburg/.openclaw/workspace/leads_engine
+set -euo pipefail
+cd "$(dirname "$0")"
 ./crawler_v2.py --mode full
 ./enrich.py
 ./brief.py

--- a/run_v4.sh
+++ b/run_v4.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
-set -e
-cd /Users/lunavanamburg/.openclaw/workspace/leads_engine
+set -euo pipefail
+cd "$(dirname "$0")"
 ./crawler_v2.py --mode full
 ./enrich.py
 ./postprocess_v4.py


### PR DESCRIPTION
Summary
- removes hardcoded workspace paths and makes scripts portable from repo root
- adds adapter registry scaffolding for multi-source ingestion
- improves canonical ingest dedupe baseline using normalized website domains
- merges canonical DB rows into downstream V4 postprocess/export flow
- adds gitignore for generated data/output artifacts

Why
This closes key V1 remaining items:
- adapter plugin scaffolding
- canonical DB integration into exports
- dedupe/entity baseline hardening

Validation
- python3 -m py_compile jobs/ingest_sources.py postprocess_v4.py crawler_v2.py enrich.py brief.py crawler.py adapters/*.py
- PYTHONPATH=$PWD python3 jobs/ingest_sources.py
- python3 postprocess_v4.py
