### PR TITLE
V1: add verification event ingestion + change reports

### DIFF
--- a/jobs/export_changes.py
+++ b/jobs/export_changes.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import csv
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1]
+DB = BASE / 'data/cannaradar_v1.db'
+SCHEMA = BASE / 'db/schema.sql'
+OUT = BASE / 'out'
+SNAPSHOT = OUT / 'outreach_dispensary_100.csv'
+STATE_DIR = BASE / 'data/state'
+PREV = STATE_DIR / 'last_outreach_snapshot.csv'
+
+
+def init_db(con: sqlite3.Connection):
+    con.executescript(SCHEMA.read_text())
+    con.commit()
+
+
+def key(row: dict) -> tuple[str, str]:
+    return (
+        (row.get('website') or '').strip().lower(),
+        (row.get('dispensary') or '').strip().lower(),
+    )
+
+
+def load_csv(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open(newline='') as f:
+        return list(csv.DictReader(f))
+
+
+def write_csv(path: Path, rows: list[dict], fieldnames: list[str]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('w', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    if not SNAPSHOT.exists():
+        raise SystemExit(f'Missing snapshot: {SNAPSHOT}. Run postprocess/export first.')
+
+    now = datetime.now().strftime('%Y%m%d-%H%M%S')
+    diff_path = OUT / f'changes_{now}.csv'
+    summary_path = OUT / f'changes_{now}.txt'
+
+    current = load_csv(SNAPSHOT)
+    previous = load_csv(PREV)
+
+    cur_map = {key(r): r for r in current}
+    prev_map = {key(r): r for r in previous}
+
+    added = [cur_map[k] for k in cur_map.keys() - prev_map.keys()]
+    removed = [prev_map[k] for k in prev_map.keys() - cur_map.keys()]
+
+    modified = []
+    tracked = ['score', 'email', 'phone', 'owner_name', 'owner_role', 'segment']
+    for k in cur_map.keys() & prev_map.keys():
+        cur = cur_map[k]
+        prev = prev_map[k]
+        changes = []
+        for f in tracked:
+            if (cur.get(f) or '') != (prev.get(f) or ''):
+                changes.append(f'{f}: "{prev.get(f, "")}" -> "{cur.get(f, "")}"')
+        if changes:
+            row = cur.copy()
+            row['change_type'] = 'modified'
+            row['changes'] = '; '.join(changes)
+            modified.append(row)
+
+    rows = []
+    for r in added:
+        x = r.copy(); x['change_type'] = 'added'; x['changes'] = ''
+        rows.append(x)
+    for r in removed:
+        x = r.copy(); x['change_type'] = 'removed'; x['changes'] = ''
+        rows.append(x)
+    rows.extend(modified)
+
+    base_fields = list(current[0].keys()) if current else ['dispensary', 'website', 'state', 'score']
+    fields = base_fields + ['change_type', 'changes']
+    write_csv(diff_path, rows, fields)
+
+    summary = [
+        f'Change Report ({now})',
+        f'Current rows: {len(current)}',
+        f'Previous rows: {len(previous)}',
+        f'Added: {len(added)}',
+        f'Removed: {len(removed)}',
+        f'Modified: {len(modified)}',
+        f'Detail CSV: {diff_path.name}',
+    ]
+    summary_path.write_text('\n'.join(summary) + '\n')
+
+    # Update baseline snapshot for next run.
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    PREV.write_text(SNAPSHOT.read_text())
+
+    print(f'Wrote {diff_path}')
+    print(f'Wrote {summary_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/jobs/log_outreach_event.py
+++ b/jobs/log_outreach_event.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1]
+DB = BASE / 'data/cannaradar_v1.db'
+SCHEMA = BASE / 'db/schema.sql'
+VALID_OUTCOMES = {'bounced', 'replied', 'confirmed', 'no-fit'}
+
+
+def init_db(con: sqlite3.Connection):
+    con.executescript(SCHEMA.read_text())
+    con.commit()
+
+
+def resolve_location_pk(con: sqlite3.Connection, location_pk: str | None, website: str | None, name: str | None, state: str | None) -> str | None:
+    if location_pk:
+        row = con.execute('SELECT location_pk FROM locations WHERE location_pk=?', (location_pk,)).fetchone()
+        return row[0] if row else None
+
+    if website:
+        w = website.strip().lower().replace('https://', '').replace('http://', '').strip('/')
+        row = con.execute(
+            '''SELECT location_pk FROM locations
+               WHERE lower(website_domain)=?
+               LIMIT 1''',
+            (w,),
+        ).fetchone()
+        if row:
+            return row[0]
+
+    if name and state:
+        row = con.execute(
+            '''SELECT location_pk FROM locations
+               WHERE lower(canonical_name)=? AND lower(state)=?
+               LIMIT 1''',
+            (name.strip().lower(), state.strip().lower()),
+        ).fetchone()
+        if row:
+            return row[0]
+
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Log outreach verification event into canonical DB')
+    ap.add_argument('--location-pk', default='')
+    ap.add_argument('--website', default='')
+    ap.add_argument('--name', default='')
+    ap.add_argument('--state', default='')
+    ap.add_argument('--channel', required=True, help='email|sms|call|linkedin|other')
+    ap.add_argument('--outcome', required=True, help='bounced|replied|confirmed|no-fit')
+    ap.add_argument('--notes', default='')
+    args = ap.parse_args()
+
+    outcome = args.outcome.strip().lower()
+    if outcome not in VALID_OUTCOMES:
+        raise SystemExit(f'Invalid outcome: {outcome}. Expected one of: {", ".join(sorted(VALID_OUTCOMES))}')
+
+    DB.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(DB)
+    init_db(con)
+
+    loc_pk = resolve_location_pk(
+        con,
+        args.location_pk or None,
+        args.website or None,
+        args.name or None,
+        args.state or None,
+    )
+    if not loc_pk:
+        raise SystemExit('Could not resolve location. Pass --location-pk, or --website, or --name + --state.')
+
+    event_pk = str(uuid.uuid4())
+    now = datetime.now().isoformat(timespec='seconds')
+    con.execute(
+        '''INSERT INTO outreach_events (event_pk, location_pk, channel, outcome, notes, created_at)
+           VALUES (?,?,?,?,?,?)''',
+        (event_pk, loc_pk, args.channel.strip().lower(), outcome, args.notes.strip(), now),
+    )
+    con.commit()
+
+    print(f'Logged outreach event: {event_pk} location={loc_pk} outcome={outcome} channel={args.channel}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Summary
- adds jobs/log_outreach_event.py to ingest outreach outcomes into canonical outreach_events
- adds jobs/export_changes.py to diff latest outreach snapshot vs previous baseline
- emits both detailed CSV and summary TXT change reports per run

Why
This closes key V1 remaining items:
- verification event ingestion path
- change/diff report utility

Validation
- python3 -m py_compile jobs/log_outreach_event.py jobs/export_changes.py
- python3 jobs/export_changes.py
- python3 jobs/log_outreach_event.py --website curaleaf.com --channel email --outcome replied --notes "test event"
