### PR TITLE
V1: runbook docs + smoke test checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ CannaRadar is built as that engine.
 
 ### Docs
 - `CANNARADAR_FULL_BUILD_SPEC.md` — full build blueprint and continuity plan
+- `docs/RUNBOOK_V1.md` — setup/run/debug/recovery operations runbook
 - `CANNARADAR_V2_IDEAS.md` — post-V1 roadmap
 - `README_V4.md` — prior v4 notes
 
@@ -60,6 +61,12 @@ To include canonical ingest before pipeline:
 
 ```bash
 ./run_v1_features.sh
+```
+
+Run smoke checks:
+
+```bash
+./run_smoke_tests.sh
 ```
 
 ---

--- a/docs/RUNBOOK_V1.md
+++ b/docs/RUNBOOK_V1.md
@@ -1,0 +1,44 @@
+# CannaRadar V1 Runbook
+
+## Purpose
+Operational guide for setup, run, debug, and recovery of the V1 pipeline.
+
+## Prereqs
+- Python 3.10+
+- Repo checked out locally
+
+## Core commands
+- Full V1 flow: `./run_v1_features.sh`
+- Crawl + enrich + postprocess: `./run_v4.sh`
+- Canonical ingest only: `PYTHONPATH=$PWD python3 jobs/ingest_sources.py`
+- Change report: `python3 jobs/export_changes.py`
+- Log verification event:
+  `python3 jobs/log_outreach_event.py --website curaleaf.com --channel email --outcome replied --notes "left voicemail"`
+
+## Key outputs
+- `out/outreach_dispensary_100.csv`
+- `out/excluded_non_dispensary.csv`
+- `out/v4_quality_report.txt`
+- `out/changes_*.csv` and `out/changes_*.txt`
+
+## Troubleshooting
+1. Missing exports
+   - Ensure upstream input exists (`out/raw_leads.csv` or `out/enriched_leads.csv`)
+   - Re-run `./run_v4.sh`
+2. No canonical DB
+   - Run `PYTHONPATH=$PWD python3 jobs/ingest_sources.py`
+3. Event logging fails to resolve location
+   - Provide `--location-pk` directly, or `--name` + `--state`
+4. Empty change report
+   - First run initializes baseline; run export again after a new snapshot
+
+## Recovery
+1. Rebuild canonical schema by rerunning ingest.
+2. Regenerate V4 outputs.
+3. Regenerate change report.
+4. Verify smoke tests pass.
+
+## Known V1 limitations
+- Owner extraction still noisy on some sites.
+- Segment classification is rule-based (not ML).
+- Coverage quality depends on seeds quality.

--- a/run_smoke_tests.sh
+++ b/run_smoke_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/zsh
+set -euo pipefail
+cd "$(dirname "$0")"
+python3 tests/smoke_v1.py

--- a/tests/smoke_v1.py
+++ b/tests/smoke_v1.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import csv
+import sqlite3
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / 'db/schema.sql'
+
+
+def assert_true(cond: bool, msg: str):
+    if not cond:
+        raise AssertionError(msg)
+
+
+def test_schema_tables():
+    with tempfile.TemporaryDirectory() as td:
+        db = Path(td) / 'test.db'
+        con = sqlite3.connect(db)
+        con.executescript(SCHEMA.read_text())
+        tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+        required = {'organizations', 'licenses', 'locations', 'contact_points', 'evidence', 'outreach_events'}
+        assert_true(required.issubset(tables), f'missing tables: {required - tables}')
+        con.close()
+
+
+def test_export_schema_contract():
+    required_cols = ['dispensary','segment','website','state','market','owner_name','owner_role','email','phone','source_url','score','checked_at']
+    out_file = ROOT / 'out' / 'outreach_dispensary_100.csv'
+    if not out_file.exists():
+        return
+    with out_file.open(newline='') as f:
+        reader = csv.DictReader(f)
+        assert_true(reader.fieldnames is not None, 'missing headers in outreach_dispensary_100.csv')
+        for c in required_cols:
+            assert_true(c in reader.fieldnames, f'missing export column: {c}')
+
+
+def main():
+    test_schema_tables()
+    test_export_schema_contract()
+    print('smoke_v1: ok')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- adds `docs/RUNBOOK_V1.md` with setup/run/debug/recovery guidance
- adds `tests/smoke_v1.py` with schema and export contract checks
- adds `run_smoke_tests.sh` convenience runner
- updates README quickstart/docs to include runbook + smoke tests

## Why
This closes the V1 remaining item for:
- runbook docs
- smoke checks

## Validation
- `./run_smoke_tests.sh`
