### PR TITLE
V1: add one-command acceptance runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Run smoke checks:
 ./run_smoke_tests.sh
 ```
 
+Run end-to-end V1 acceptance pass:
+
+```bash
+./run_v1_acceptance.sh
+```
+
 ---
 
 ## Outputs

--- a/docs/RUNBOOK_V1.md
+++ b/docs/RUNBOOK_V1.md
@@ -12,6 +12,8 @@ Operational guide for setup, run, debug, and recovery of the V1 pipeline.
 - Crawl + enrich + postprocess: `./run_v4.sh`
 - Canonical ingest only: `PYTHONPATH=$PWD python3 jobs/ingest_sources.py`
 - Change report: `python3 jobs/export_changes.py`
+- Smoke checks: `./run_smoke_tests.sh`
+- Full acceptance pass: `./run_v1_acceptance.sh`
 - Log verification event:
   `python3 jobs/log_outreach_event.py --website curaleaf.com --channel email --outcome replied --notes "left voicemail"`
 

--- a/run_v1_acceptance.sh
+++ b/run_v1_acceptance.sh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "[1/4] Canonical ingest + pipeline"
+./run_v1_features.sh
+
+echo "[2/4] Change report"
+python3 jobs/export_changes.py
+
+echo "[3/4] Smoke tests"
+./run_smoke_tests.sh
+
+echo "[4/4] Acceptance summary"
+python3 - <<'PY'
+from pathlib import Path
+root = Path('.')
+required = [
+    root/'out'/'outreach_dispensary_100.csv',
+    root/'out'/'excluded_non_dispensary.csv',
+    root/'out'/'v4_quality_report.txt',
+    root/'out'/'morning_brief.txt',
+]
+missing = [str(p) for p in required if not p.exists()]
+if missing:
+    print('Missing required outputs:')
+    for m in missing:
+        print('-', m)
+    raise SystemExit(1)
+print('V1 acceptance runner complete. Required outputs present.')
+PY


### PR DESCRIPTION
Summary
- adds run_v1_acceptance.sh to run the full V1 acceptance sequence in one command
- sequence includes: run_v1_features, export_changes, smoke tests, output presence check
- updates README and RUNBOOK_V1 references

Why
Makes V1 validation repeatable before/after merges and during ops handoffs.

Validation
- ./run_smoke_tests.sh
- ./run_v1_acceptance.sh
