### PR TITLE
Fix: active-row filter regression in score/export/quality

### DIFF
--- a/pipeline/quality.py
+++ b/pipeline/quality.py
@@ -1,85 +1,86 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
-from collections import Counter
 
 
 def run_quality_report(con, out_dir: Path) -> dict[str, object]:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    total = con.execute("SELECT COUNT(*) AS c FROM locations WHERE deleted_at IS NULL").fetchone()["c"]
+    total = con.execute("SELECT COUNT(*) AS c FROM locations WHERE COALESCE(deleted_at,'')=''").fetchone()["c"]
     with_email = con.execute(
         "SELECT COUNT(*) AS c FROM locations l "
-        "WHERE l.deleted_at IS NULL AND EXISTS (SELECT 1 FROM contact_points cp WHERE cp.location_pk=l.location_pk AND cp.type='email' AND cp.value<>'')",
+        "WHERE COALESCE(l.deleted_at,'')='' AND EXISTS (SELECT 1 FROM contact_points cp WHERE cp.location_pk=l.location_pk AND cp.type='email' AND cp.value<>'')",
     ).fetchone()["c"]
     with_buyer = con.execute(
         "SELECT COUNT(*) AS c FROM locations l "
-        "WHERE l.deleted_at IS NULL AND EXISTS (SELECT 1 FROM contacts c WHERE c.location_pk=l.location_pk AND LOWER(c.role) LIKE '%buyer%')",
+        "WHERE COALESCE(l.deleted_at,'')='' AND EXISTS (SELECT 1 FROM contacts c WHERE c.location_pk=l.location_pk AND LOWER(c.role) LIKE '%buyer%')",
     ).fetchone()["c"]
-
-    duplicate_domains = con.execute(
-        "SELECT COUNT(*) AS dups FROM (SELECT website_domain FROM locations WHERE deleted_at IS NULL AND website_domain<>'' GROUP BY website_domain HAVING COUNT(*)>1)",
+    dup_domains = con.execute(
+        "SELECT COUNT(*) AS dups FROM (SELECT website_domain FROM locations WHERE COALESCE(deleted_at,'')='' AND website_domain<>'' GROUP BY website_domain HAVING COUNT(*)>1)",
     ).fetchone()["dups"]
 
     freshness_rows = con.execute(
-        "SELECT last_seen_at FROM locations WHERE deleted_at IS NULL",
+        "SELECT last_seen_at FROM locations WHERE COALESCE(deleted_at,'')=''",
     ).fetchall()
-    now = datetime.now(timezone.utc)
-    buckets = Counter()
+    buckets = {"0-7d": 0, "8-30d": 0, "31-90d": 0, "90d+": 0, "unknown": 0}
+    now = datetime.now()
     for row in freshness_rows:
-        ts = row["last_seen_at"]
-        if not ts:
+        value = (row["last_seen_at"] or "").strip()
+        if not value:
             buckets["unknown"] += 1
             continue
         try:
-            delta = (now - datetime.fromisoformat(ts)).days
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            age = (now - dt.replace(tzinfo=None)).days
         except Exception:
-            buckets["invalid"] += 1
+            buckets["unknown"] += 1
             continue
-        if delta <= 1:
-            buckets["0-1d"] += 1
-        elif delta <= 7:
-            buckets["2-7d"] += 1
-        elif delta <= 30:
+        if age <= 7:
+            buckets["0-7d"] += 1
+        elif age <= 30:
             buckets["8-30d"] += 1
+        elif age <= 90:
+            buckets["31-90d"] += 1
         else:
-            buckets["31+d"] += 1
+            buckets["90d+"] += 1
 
-    provider_rows = con.execute(
-        "SELECT field_value, COUNT(*) AS c FROM evidence WHERE field_name='menu_provider' AND entity_type='location' AND deleted_at IS NULL GROUP BY field_value ORDER BY c DESC LIMIT 10",
+    top_menu = con.execute(
+        "SELECT field_value, COUNT(*) AS c FROM evidence WHERE field_name='menu_provider' AND entity_type='location' AND COALESCE(deleted_at,'')='' GROUP BY field_value ORDER BY c DESC LIMIT 10",
     ).fetchall()
 
-    report = {
+    metrics = {
         "generated_at": datetime.now().isoformat(timespec="seconds"),
-        "total_active_leads": int(total or 0),
-        "pct_leads_with_email": round((with_email / total * 100.0), 2) if total else 0.0,
-        "pct_leads_with_buyer_title": round((with_buyer / total * 100.0), 2) if total else 0.0,
-        "duplicate_domain_rate": round((duplicate_domains / total * 100.0), 2) if total else 0.0,
-        "freshness_distribution": dict(buckets),
-        "top_menu_providers": [f"{r['field_value']}:{r['c']}" for r in provider_rows],
+        "total_active_leads": int(total),
+        "pct_leads_with_email": round((with_email / total) * 100, 2) if total else 0.0,
+        "pct_leads_with_buyer_title": round((with_buyer / total) * 100, 2) if total else 0.0,
+        "duplicate_domain_rate": round((dup_domains / total) * 100, 2) if total else 0.0,
+        "freshness_distribution": buckets,
+        "top_menu_providers": [
+            {"provider": r["field_value"], "count": int(r["c"])}
+            for r in top_menu
+            if (r["field_value"] or "").strip()
+        ],
     }
 
-    text_path = out_dir / "v4_quality_report.txt"
-    lines = [
-        f"CannaRadar Quality Report ({report['generated_at']})",
-        f"Total active locations: {report['total_active_leads']}",
-        f"Leads w/ email: {report['pct_leads_with_email']}%",
-        f"Leads w/ buyer-ish role: {report['pct_leads_with_buyer_title']}%",
-        f"Duplicate domain rate: {report['duplicate_domain_rate']}%",
-        "Freshness buckets:",
-    ]
-    for k, v in sorted(buckets.items()):
-        lines.append(f"  {k}: {v}")
-    lines.append("Top menu providers:")
-    for item in report["top_menu_providers"]:
-        lines.append(f"  - {item}")
-    text_path.write_text("\n".join(lines) + "\n")
-
+    out_dir.mkdir(parents=True, exist_ok=True)
+    txt_path = out_dir / "v4_quality_report.txt"
     json_path = out_dir / "quality_report.json"
-    json_path.write_text(json.dumps(report, indent=2))
-    return {
-        "text": str(text_path),
-        "json": str(json_path),
-        "metrics": report,
-    }
+
+    txt_lines = [
+        f"Quality Report ({metrics['generated_at']})",
+        f"Total active leads: {metrics['total_active_leads']}",
+        f"% with email: {metrics['pct_leads_with_email']}",
+        f"% with buyer-ish title: {metrics['pct_leads_with_buyer_title']}",
+        f"Duplicate domain rate: {metrics['duplicate_domain_rate']}",
+        "Freshness:",
+    ]
+    for key, value in metrics["freshness_distribution"].items():
+        txt_lines.append(f"- {key}: {value}")
+    txt_lines.append("Top menu providers:")
+    for row in metrics["top_menu_providers"]:
+        txt_lines.append(f"- {row['provider']}: {row['count']}")
+
+    txt_path.write_text("\n".join(txt_lines) + "\n", encoding="utf-8")
+    json_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    return {"text": str(txt_path), "json": str(json_path), "metrics": metrics}

--- a/pipeline/stages/enrich.py
+++ b/pipeline/stages/enrich.py
@@ -41,7 +41,7 @@ def run_waterfall_enrichment(con, location_pk: str) -> None:
         (location_pk,),
     ).fetchone()
     person = con.execute(
-        "SELECT full_name, role FROM contacts WHERE location_pk=? AND deleted_at IS NULL ORDER BY confidence DESC, updated_at DESC LIMIT 1",
+        "SELECT full_name, role FROM contacts WHERE location_pk=? AND COALESCE(deleted_at,'')='' ORDER BY confidence DESC, updated_at DESC LIMIT 1",
         (location_pk,),
     ).fetchone()
 

--- a/pipeline/stages/export.py
+++ b/pipeline/stages/export.py
@@ -46,7 +46,7 @@ def _best_contact(con, location_pk: str) -> tuple[str, str, str]:
         """
         SELECT full_name, role, email
         FROM contacts
-        WHERE location_pk = ? AND deleted_at IS NULL
+        WHERE location_pk = ? AND COALESCE(deleted_at,'')=''
         ORDER BY confidence DESC, updated_at DESC
         LIMIT 1
         """,
@@ -108,7 +108,7 @@ def export_outreach(con, out_dir: Path, tier: str = "A", limit: int = 200, run_i
     excluded_out = out_dir / "excluded_non_dispensary.csv"
 
     rows = con.execute(
-        "SELECT location_pk, canonical_name, website_domain, state FROM locations WHERE deleted_at IS NULL ORDER BY fit_score DESC, updated_at DESC"
+        "SELECT location_pk, canonical_name, website_domain, state FROM locations WHERE COALESCE(deleted_at,'')='' ORDER BY fit_score DESC, updated_at DESC"
     ).fetchall()
     tier_order = {"A": 3, "B": 2, "C": 1}
     min_tier = tier_order.get(tier, 3)
@@ -253,7 +253,7 @@ def export_research_queue(con, out_dir: Path, limit: int = 200, run_id: str = ""
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "research_queue.csv"
     rows = con.execute(
-        "SELECT location_pk, canonical_name, website_domain FROM locations WHERE deleted_at IS NULL ORDER BY fit_score DESC",
+        "SELECT location_pk, canonical_name, website_domain FROM locations WHERE COALESCE(deleted_at,'')='' ORDER BY fit_score DESC",
     ).fetchall()
     candidates: list[dict] = []
     for row in rows:
@@ -262,7 +262,7 @@ def export_research_queue(con, out_dir: Path, limit: int = 200, run_id: str = ""
             """
             SELECT 1 FROM contacts
             WHERE location_pk = ?
-              AND deleted_at IS NULL
+              AND COALESCE(deleted_at,'')=''
               AND (
                 lower(role) LIKE '%buyer%'
                 OR lower(role) LIKE '%purchasing%'

--- a/pipeline/stages/score.py
+++ b/pipeline/stages/score.py
@@ -82,7 +82,7 @@ def _parse_tier_chain(signal: str) -> bool:
 def run_score(con):
     now = utcnow_iso()
     rows = con.execute(
-        "SELECT location_pk, canonical_name, website_domain, fit_score, state FROM locations WHERE deleted_at IS NULL"
+        "SELECT location_pk, canonical_name, website_domain, fit_score, state FROM locations WHERE COALESCE(deleted_at,'')=''"
     ).fetchall()
     for row in rows:
         loc_pk = row["location_pk"]
@@ -97,7 +97,7 @@ def run_score(con):
             (loc_pk,),
         ).fetchone()
         contacts = con.execute(
-            "SELECT full_name, role FROM contacts WHERE location_pk=? AND deleted_at IS NULL AND full_name<>''",
+            "SELECT full_name, role FROM contacts WHERE location_pk=? AND COALESCE(deleted_at,'')='' AND full_name<>''",
             (loc_pk,),
         ).fetchall()
 
@@ -112,7 +112,7 @@ def run_score(con):
 
         org_pk = con.execute("SELECT org_pk FROM locations WHERE location_pk=?", (loc_pk,)).fetchone()["org_pk"]
         location_count = con.execute(
-            "SELECT COUNT(*) AS c FROM locations WHERE org_pk=? AND deleted_at IS NULL",
+            "SELECT COUNT(*) AS c FROM locations WHERE org_pk=? AND COALESCE(deleted_at,'')=''",
             (org_pk,),
         ).fetchone()["c"]
 


### PR DESCRIPTION
Summary
- fixes active-record filtering across scoring, export, quality, and enrichment stages
- updates queries to use `COALESCE(deleted_at,'')=''` to match current soft-delete semantics

Impact
- restores non-empty lead visibility in pipeline outputs
- prevents score/export stages from treating all locations as deleted

Validation
- reran score and export on current DB
- outreach output no longer empty
- quality report now reflects active rows
