### PR TITLE
fix: productionize provider-intel agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ python3.11 provider_intel_cli.py export --json --limit 100
 If you want an AI agent to operate this repository end to end, give it the repo
 root, the seed scope, the run limits, and the output you expect. The agent
 should use the canonical CLI and keep the evidence-first safety rules intact.
+This loop is an external agent workflow around the CLI, not a separate internal
+pipeline stage.
 
 Minimum handoff:
 
@@ -127,6 +129,7 @@ python3.11 provider_intel_cli.py export --json --limit 100
 How the loop should be used:
 
 - Start bounded, not broad. Small runs make blocked domains, bad seeds, and noisy extraction easier to diagnose.
+- Use `--crawl-mode refresh` when you want the same stage order with smaller fetch budgets from the `monitor*` config settings.
 - Treat `review_queue` as a normal output lane, not a failure.
 - Use `control --run-id latest show` to inspect the current run before changing config or code.
 - Resume with `sync --resume latest` when a run was interrupted or when you want to continue from checkpoints.

--- a/cli/app.py
+++ b/cli/app.py
@@ -125,13 +125,23 @@ def _dispatch(args) -> dict[str, object]:
     if args.command == "init":
         return execute_init(args)
     if args.command == "doctor":
-        return run_doctor(db_path=args.db, config_path=args.config, run_state_dir=args.checkpoint_dir)
+        return run_doctor(
+            db_path=args.db,
+            config_path=args.config,
+            run_state_dir=args.checkpoint_dir,
+            db_timeout_ms=args.db_timeout_ms,
+        )
     if args.command == "sync":
         return execute_sync(args)
     if args.command == "tail":
         return execute_tail(args)
     if args.command == "status":
-        return run_status(db_path=args.db, run_id=args.run_id, run_state_dir=args.checkpoint_dir)
+        return run_status(
+            db_path=args.db,
+            run_id=args.run_id,
+            run_state_dir=args.checkpoint_dir,
+            db_timeout_ms=args.db_timeout_ms,
+        )
     if args.command == "control":
         if args.control_action == "show":
             return run_control_show(run_id=args.run_id, run_state_dir=args.checkpoint_dir)
@@ -142,9 +152,20 @@ def _dispatch(args) -> dict[str, object]:
             action_value = args.max_pages
         return run_control_apply(run_id=args.run_id, run_state_dir=args.checkpoint_dir, action=args.control_action, domain=args.domain, value=action_value, reason=args.reason)
     if args.command == "sql":
-        return run_sql(db_path=args.db, query=args.query_flag or args.query or "", limit=args.limit)
+        return run_sql(
+            db_path=args.db,
+            query=args.query_flag or args.query or "",
+            limit=args.limit,
+            db_timeout_ms=args.db_timeout_ms,
+        )
     if args.command == "search":
-        return run_search(db_path=args.db, query=args.query, preset=args.preset, limit=args.limit)
+        return run_search(
+            db_path=args.db,
+            query=args.query,
+            preset=args.preset,
+            limit=args.limit,
+            db_timeout_ms=args.db_timeout_ms,
+        )
     if args.command == "export":
         return execute_export(args)
     raise RuntimeError(f"Unsupported command: {args.command}")
@@ -163,6 +184,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.config:
             resolved = str(Path(args.config).expanduser().resolve())
             os.environ["PROVIDER_INTEL_CONFIG"] = resolved
+            os.environ["PROVIDER_INTEL_CRAWLER_CONFIG"] = resolved
             os.environ["CANNARADAR_CRAWLER_CONFIG"] = resolved
         command = args.command
         data = _dispatch(args)

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -11,7 +11,7 @@ from typing import Any
 from cli.errors import ConfigError
 from jobs.ingest_sources import assert_schema_layout, assert_schema_migration, init_db
 from pipeline.config import DEFAULT_CONFIG_PATH, CrawlConfig, load_crawl_config
-from pipeline.db import connect_db
+from pipeline.db import connect_db, normalized_db_timeout_ms, sqlite_timeout_seconds
 from pipeline.run_state import ensure_run_state_dir
 
 
@@ -24,7 +24,11 @@ MIN_FREE_BYTES = 128 * 1024 * 1024
 def resolve_config_path(cli_value: str | None) -> Path:
     if cli_value:
         return Path(cli_value).expanduser().resolve()
-    env_value = os.environ.get("PROVIDER_INTEL_CONFIG") or os.environ.get("CANNARADAR_CRAWLER_CONFIG")
+    env_value = (
+        os.environ.get("PROVIDER_INTEL_CONFIG")
+        or os.environ.get("PROVIDER_INTEL_CRAWLER_CONFIG")
+        or os.environ.get("CANNARADAR_CRAWLER_CONFIG")
+    )
     if env_value:
         return Path(env_value).expanduser().resolve()
     return DEFAULT_CONFIG_PATH.resolve()
@@ -40,8 +44,9 @@ def check_item(check_id: str, status: str, summary: str, *, details: dict[str, A
     }
 
 
-def run_doctor(*, db_path: str, config_path: str | None, run_state_dir: str | None) -> dict[str, Any]:
+def run_doctor(*, db_path: str, config_path: str | None, run_state_dir: str | None, db_timeout_ms: int | None = None) -> dict[str, Any]:
     resolved_config = resolve_config_path(config_path)
+    effective_timeout_ms = normalized_db_timeout_ms(db_timeout_ms)
     checks: list[dict[str, Any]] = []
     cfg: CrawlConfig | None = None
 
@@ -109,14 +114,18 @@ def run_doctor(*, db_path: str, config_path: str | None, run_state_dir: str | No
             checks.append(check_item(f"writable_{label}", "fail", f"Cannot write to {path}: {exc}", remediation="Fix permissions."))
 
     try:
-        con = connect_db(Path(db_path).expanduser().resolve())
+        con = connect_db(Path(db_path).expanduser().resolve(), timeout_ms=effective_timeout_ms)
         con.close()
         checks.append(check_item("db_connectivity", "pass", f"SQLite DB is reachable: {db_path}"))
     except Exception as exc:
         checks.append(check_item("db_connectivity", "fail", f"Failed to open SQLite DB: {exc}", remediation="Check the DB path and permissions."))
 
     try:
-        con = sqlite3.connect(Path(db_path).expanduser().resolve())
+        con = sqlite3.connect(
+            Path(db_path).expanduser().resolve(),
+            timeout=sqlite_timeout_seconds(effective_timeout_ms),
+        )
+        con.execute(f"PRAGMA busy_timeout = {effective_timeout_ms}")
         assert_schema_layout(con)
         assert_schema_migration(con)
         con.close()
@@ -222,9 +231,10 @@ def _config_requires_provider_rewrite(path: Path) -> bool:
     return not seed_file.endswith("seed_pack.json")
 
 
-def run_init(*, db_path: str, config_path: str | None, run_state_dir: str | None) -> dict[str, Any]:
+def run_init(*, db_path: str, config_path: str | None, run_state_dir: str | None, db_timeout_ms: int | None = None) -> dict[str, Any]:
     resolved_config = resolve_config_path(config_path)
     resolved_db = Path(db_path).expanduser().resolve()
+    effective_timeout_ms = normalized_db_timeout_ms(db_timeout_ms)
     resolved_db.parent.mkdir(parents=True, exist_ok=True)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -238,11 +248,17 @@ def run_init(*, db_path: str, config_path: str | None, run_state_dir: str | None
         resolved_policy.parent.mkdir(parents=True, exist_ok=True)
         resolved_policy.write_text(json.dumps(default_fetch_policies_payload(), indent=2), encoding="utf-8")
 
-    con = sqlite3.connect(resolved_db)
+    con = sqlite3.connect(resolved_db, timeout=sqlite_timeout_seconds(effective_timeout_ms))
+    con.execute(f"PRAGMA busy_timeout = {effective_timeout_ms}")
     init_db(con)
     con.close()
 
-    doctor = run_doctor(db_path=str(resolved_db), config_path=str(resolved_config), run_state_dir=run_state_dir)
+    doctor = run_doctor(
+        db_path=str(resolved_db),
+        config_path=str(resolved_config),
+        run_state_dir=run_state_dir,
+        db_timeout_ms=effective_timeout_ms,
+    )
     return {
         "ok": doctor["ok"],
         "db_path": str(resolved_db),

--- a/cli/query.py
+++ b/cli/query.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from cli.errors import ConfigError, DataValidationError
+from pipeline.db import normalized_db_timeout_ms, sqlite_timeout_seconds
 from pipeline.run_control import load_run_control, summarize_run_control
 from pipeline.run_state import latest_run_state, load_run_state
 
@@ -64,11 +65,17 @@ PRESET_QUERIES = {
 }
 
 
-def _connect_readonly(db_path: str | Path) -> sqlite3.Connection:
+def _connect_readonly(db_path: str | Path, *, db_timeout_ms: int | None = None) -> sqlite3.Connection:
     path = Path(db_path).expanduser().resolve()
     if not path.exists():
         raise ConfigError(f"SQLite DB not found: {path}")
-    con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    effective_timeout_ms = normalized_db_timeout_ms(db_timeout_ms)
+    con = sqlite3.connect(
+        f"file:{path}?mode=ro",
+        uri=True,
+        timeout=sqlite_timeout_seconds(effective_timeout_ms),
+    )
+    con.execute(f"PRAGMA busy_timeout = {effective_timeout_ms}")
     con.row_factory = sqlite3.Row
     con.execute("PRAGMA query_only = ON")
     return con
@@ -96,7 +103,7 @@ def _file_snapshot(path: Path) -> dict[str, Any]:
     }
 
 
-def run_status(*, db_path: str, run_id: str | None, run_state_dir: str | None) -> dict[str, Any]:
+def run_status(*, db_path: str, run_id: str | None, run_state_dir: str | None, db_timeout_ms: int | None = None) -> dict[str, Any]:
     manifest = _read_json(MANIFEST_PATH) or {}
     checkpoint = None
     if run_id:
@@ -115,7 +122,7 @@ def run_status(*, db_path: str, run_id: str | None, run_state_dir: str | None) -
         except FileNotFoundError:
             control_summary = {}
 
-    con = _connect_readonly(db_path)
+    con = _connect_readonly(db_path, db_timeout_ms=db_timeout_ms)
     counts = {
         "providers": int(con.execute("SELECT COUNT(*) FROM providers").fetchone()[0]),
         "practices": int(con.execute("SELECT COUNT(*) FROM practices").fetchone()[0]),
@@ -150,8 +157,8 @@ def run_status(*, db_path: str, run_id: str | None, run_state_dir: str | None) -
     }
 
 
-def run_search(*, db_path: str, query: str | None, preset: str | None, limit: int) -> dict[str, Any]:
-    con = _connect_readonly(db_path)
+def run_search(*, db_path: str, query: str | None, preset: str | None, limit: int, db_timeout_ms: int | None = None) -> dict[str, Any]:
+    con = _connect_readonly(db_path, db_timeout_ms=db_timeout_ms)
     try:
         if preset:
             sql = PRESET_QUERIES.get(preset)
@@ -183,7 +190,7 @@ def run_search(*, db_path: str, query: str | None, preset: str | None, limit: in
         con.close()
 
 
-def run_sql(*, db_path: str, query: str, limit: int) -> dict[str, Any]:
+def run_sql(*, db_path: str, query: str, limit: int, db_timeout_ms: int | None = None) -> dict[str, Any]:
     normalized = (query or "").strip()
     if not normalized:
         raise DataValidationError("SQL query is required.")
@@ -193,7 +200,7 @@ def run_sql(*, db_path: str, query: str, limit: int) -> dict[str, Any]:
     if any(term in lowered for term in FORBIDDEN_SQL_TERMS):
         raise DataValidationError("SQL command must be read-only.")
 
-    con = _connect_readonly(db_path)
+    con = _connect_readonly(db_path, db_timeout_ms=db_timeout_ms)
     try:
         rows = con.execute(f"SELECT * FROM ({normalized}) LIMIT ?", (limit,)).fetchall()
         data = [dict(row) for row in rows]

--- a/cli/sync.py
+++ b/cli/sync.py
@@ -25,8 +25,28 @@ from pipeline.run_state import (
 from pipeline.utils import utcnow_iso
 
 
-def _build_runner(run_id: str, *, db_path: str, seeds_path: str, args, runner_factory=PipelineRunner) -> PipelineRunner:
-    runner = runner_factory(seeds=seeds_path, db_path=db_path)
+def _runner_config_overrides(options: dict[str, Any]) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    headless = str(options.get("crawlee_headless") or "").strip().lower()
+    if headless in {"on", "off"}:
+        overrides["crawlee_headless"] = headless == "on"
+    return overrides
+
+
+def _runner_factory_kwargs(*, args, options: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "db_timeout_ms": getattr(args, "db_timeout_ms", None),
+        "config_overrides": _runner_config_overrides(options),
+        "crawl_mode": str(options.get("crawl_mode") or "full"),
+    }
+
+
+def _build_runner(run_id: str, *, db_path: str, seeds_path: str, args, options: dict[str, Any], runner_factory=PipelineRunner) -> PipelineRunner:
+    runner = runner_factory(
+        seeds=seeds_path,
+        db_path=db_path,
+        **_runner_factory_kwargs(args=args, options=options),
+    )
     runner.job_id = run_id
     return runner
 
@@ -67,7 +87,11 @@ def execute_sync(args, *, runner_factory=PipelineRunner) -> dict[str, Any]:
         db_path = str(state.get("db_path") or getattr(args, "db", DB_PATH))
     else:
         options = _sync_options_from_args(args)
-        bootstrap = runner_factory(seeds=getattr(args, "seeds", "seed_packs/nj/seed_pack.json"), db_path=getattr(args, "db", DB_PATH))
+        bootstrap = runner_factory(
+            seeds=getattr(args, "seeds", "seed_packs/nj/seed_pack.json"),
+            db_path=getattr(args, "db", DB_PATH),
+            **_runner_factory_kwargs(args=args, options=options),
+        )
         run_id = getattr(args, "run_id", None) or bootstrap.job_id
         seeds_path = bootstrap.seeds_path
         db_path = str(Path(getattr(args, "db", DB_PATH)).expanduser().resolve())
@@ -83,7 +107,14 @@ def execute_sync(args, *, runner_factory=PipelineRunner) -> dict[str, Any]:
         save_run_state(state, checkpoint_dir)
 
     ensure_run_control(run_id, checkpoint_dir)
-    runner = _build_runner(run_id, db_path=db_path, seeds_path=seeds_path, args=args, runner_factory=runner_factory)
+    runner = _build_runner(
+        run_id,
+        db_path=db_path,
+        seeds_path=seeds_path,
+        args=args,
+        options=options,
+        runner_factory=runner_factory,
+    )
     state["db_path"] = db_path
     state["seeds_path"] = seeds_path
     report = dict(state.get("report") or {})
@@ -205,10 +236,18 @@ def execute_tail(args, *, runner_factory=PipelineRunner) -> dict[str, Any]:
 
 
 def execute_export(args, *, runner_factory=PipelineRunner) -> dict[str, Any]:
-    runner = runner_factory(db_path=getattr(args, "db", DB_PATH))
+    runner = runner_factory(
+        db_path=getattr(args, "db", DB_PATH),
+        db_timeout_ms=getattr(args, "db_timeout_ms", None),
+    )
     result = runner.run_export(limit=int(getattr(args, "limit", 100) or 100))
     return result
 
 
 def execute_init(args) -> dict[str, Any]:
-    return run_init(db_path=getattr(args, "db", DB_PATH), config_path=getattr(args, "config", None), run_state_dir=getattr(args, "checkpoint_dir", None))
+    return run_init(
+        db_path=getattr(args, "db", DB_PATH),
+        config_path=getattr(args, "config", None),
+        run_state_dir=getattr(args, "checkpoint_dir", None),
+        db_timeout_ms=getattr(args, "db_timeout_ms", None),
+    )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,8 @@ What is outside the runtime:
 
 ## Notes On Accuracy And Current Gaps
 
-- `--crawl-mode` is accepted by `cli/app.py` and stored in run metadata by `cli/sync.py`, but the current stage runner does not branch on it.
-- `--crawlee-headless` is also stored in sync options, but the fetch layer still reads effective headless mode from config or env via `pipeline/config.py`.
+- The documented "agentic research loop" is an external agent/operator loop around the CLI, not a separate runtime stage.
+- `--crawl-mode refresh` changes fetch breadth by using `monitorMaxPagesPerDomain`, `monitorMaxTotalPages`, and `monitorMaxDepth`, but it keeps the same stage order and still performs a fresh-run table reset in `seed_ingest`.
+- `--crawlee-headless on|off` now overrides the effective browser headless setting for the current sync run.
+- `--db-timeout-ms` now sets SQLite connection timeout and `PRAGMA busy_timeout` for writable and read-only CLI connections.
 - `pipeline/quality.py` is legacy code from the prior product surface and is not part of the active provider-intel execution path.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,8 +9,8 @@ The canonical CLI entrypoint is `provider_intel_cli.py`. The retired `cannaradar
 | Flag | Meaning | Notes |
 | --- | --- | --- |
 | `--db` | Alternate SQLite path | Defaults to `data/provider_intel_v1.db` |
-| `--db-timeout-ms` | Declared SQLite timeout | Accepted by `cli/app.py`, currently not consumed by `pipeline/db.py` |
-| `--config` | Alternate `crawler_config.json` | Also sets `PROVIDER_INTEL_CONFIG` and `CANNARADAR_CRAWLER_CONFIG` for the process |
+| `--db-timeout-ms` | SQLite timeout in milliseconds | Applied to writable and read-only CLI DB connections, and mirrored to `PRAGMA busy_timeout` |
+| `--config` | Alternate `crawler_config.json` | Also sets `PROVIDER_INTEL_CONFIG`, `PROVIDER_INTEL_CRAWLER_CONFIG`, and the legacy compatibility alias `CANNARADAR_CRAWLER_CONFIG` for the process |
 | `--json` | Emit strict JSON envelope | Uses schema `provider_intel.cli.v1` |
 | `--plain` | Emit plain-text output | Default |
 
@@ -70,9 +70,9 @@ Flags:
 | --- | --- | --- |
 | `--seeds` | Seed pack path | Active |
 | `--max` | Seed limit | Active |
-| `--crawl-mode` | `full` or `refresh` | Stored in checkpoint metadata; current pipeline does not branch on it |
+| `--crawl-mode` | `full` or `refresh` | `refresh` uses `monitorMaxPagesPerDomain`, `monitorMaxTotalPages`, and `monitorMaxDepth` to narrow fetch breadth while keeping the same stage order |
 | `--limit` | Export limit | Active, passed to export |
-| `--crawlee-headless` | `on` or `off` | Stored in sync options; current fetch layer still reads headless mode from config/env |
+| `--crawlee-headless` | `on` or `off` | Overrides the effective browser headless mode for that sync run |
 | `--run-id` | Explicit run id | Active |
 | `--resume` | Resume a checkpoint by id or `latest` | Active |
 | `--checkpoint-dir` | Alternate checkpoint directory | Active |
@@ -231,6 +231,12 @@ python3.11 provider_intel_cli.py doctor --json
 python3.11 provider_intel_cli.py sync --json --seeds seed_packs/examples/cassia_live_test.json --max 2 --limit 10
 python3.11 provider_intel_cli.py status --json
 python3.11 provider_intel_cli.py search --json --preset review-queue
+```
+
+### Refresh-mode bounded run
+
+```bash
+python3.11 provider_intel_cli.py sync --json --crawl-mode refresh --max 10 --limit 25
 ```
 
 ### Resume after a failure

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,11 +36,15 @@ Yes, that is the closest thing to a sales list in the current runtime. It still 
 
 ## Does `--crawl-mode refresh` change behavior today?
 
-Not yet. It is stored in run metadata, but the current sync path does not branch on it.
+Yes. It narrows the crawl stage by using `monitorMaxPagesPerDomain`,
+`monitorMaxTotalPages`, and `monitorMaxDepth` from `crawler_config.json`.
+It still runs the same stage order and still rebuilds the active provider-intel
+tables on a fresh run.
 
 ## Does `--crawlee-headless off` force visible browser crawling today?
 
-Not directly. The flag is parsed and stored, but current effective headless behavior still comes from config or environment.
+Yes for the current sync run. It overrides the effective browser headless mode
+without requiring you to rewrite `crawler_config.json`.
 
 ## How do I stop a noisy domain without editing code?
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,6 +45,15 @@ Success criteria:
 python3.11 provider_intel_cli.py sync --json --max 10 --limit 25
 ```
 
+### Refresh-mode bounded run
+
+Use this when you want the full stage sequence with smaller crawl budgets from
+the `monitor*` settings in `crawler_config.json`.
+
+```bash
+python3.11 provider_intel_cli.py sync --json --crawl-mode refresh --max 10 --limit 25
+```
+
 ### Bounded live test
 
 ```bash

--- a/docs/runtime-and-pipeline.md
+++ b/docs/runtime-and-pipeline.md
@@ -14,6 +14,16 @@ The pipeline is orchestrated by `cli/sync.py` and `pipeline/pipeline.py`. A sync
 6. `qa`
 7. `export`
 
+`sync --crawl-mode refresh` uses the monitor fetch budgets from
+`crawler_config.json` for the crawl stage:
+
+- `monitorMaxPagesPerDomain`
+- `monitorMaxTotalPages`
+- `monitorMaxDepth`
+
+It does not change the stage order, and on a fresh run it still rebuilds the
+active provider-intel tables during `seed_ingest`.
+
 ## Full Run Sequence
 
 ```mermaid
@@ -273,6 +283,7 @@ stateDiagram-v2
 
 ## Known Behavioral Nuances
 
-- `sync --crawl-mode refresh` currently records the mode in checkpoint metadata but does not alter stage execution.
-- `sync --crawlee-headless on|off` is accepted by the CLI and stored in run options, but effective headless behavior still comes from config or environment.
+- `sync --crawl-mode refresh` narrows fetch breadth only; it is not an incremental DB-preservation mode.
+- `sync --crawlee-headless on|off` overrides the effective browser headless mode for that sync run.
+- The documented agentic research loop is an external CLI operating loop for an agent, not a separate internal stage.
 - Export PDFs are currently fallback PDFs from Markdown, not Playwright-rendered layouts.

--- a/docs/security-and-safety.md
+++ b/docs/security-and-safety.md
@@ -25,16 +25,17 @@ What it does not do:
 Supported config/env entrypoints:
 
 - `PROVIDER_INTEL_CONFIG`
-- `CANNARADAR_CRAWLER_CONFIG`
-- `CANNARADAR_DENYLIST`
-- `CANNARADAR_SEED_FILE`
-- `CANNARADAR_CRAWLEE_HEADLESS`
-- `CANNARADAR_CRAWLEE_PROXY_URLS`
-- `CANNARADAR_CRAWLEE_DOMAIN_POLICIES_FILE`
+- `PROVIDER_INTEL_CRAWLER_CONFIG`
+- `PROVIDER_INTEL_DENYLIST`
+- `PROVIDER_INTEL_SEED_FILE`
+- `PROVIDER_INTEL_CRAWLEE_HEADLESS`
+- `PROVIDER_INTEL_CRAWLEE_PROXY_URLS`
+- `PROVIDER_INTEL_CRAWLEE_DOMAIN_POLICIES_FILE`
 
 Notes:
 
 - These are convenience config inputs, not a secret management system.
+- Legacy `CANNARADAR_*` aliases remain accepted for compatibility, but new automation should prefer the `PROVIDER_INTEL_*` names.
 - Proxy URLs may contain credentials depending on how the operator configures them, so treat config and shell history accordingly.
 - The current code does not redact config values before logging them elsewhere.
 

--- a/docs/testing-and-quality.md
+++ b/docs/testing-and-quality.md
@@ -39,7 +39,7 @@ The current suite is mostly contract and fixture driven. It proves the core pipe
 
 Important nuance:
 
-- `tests/test_fetch_integration.py` is opt-in and only runs when `CANNARADAR_RUN_FETCH_INTEGRATION=1`.
+- `tests/test_fetch_integration.py` is opt-in and only runs when `PROVIDER_INTEL_RUN_FETCH_INTEGRATION=1`.
 - `pipeline/quality.py` is not part of the active provider-intel pipeline and is not a release gate.
 
 ## Recommended Test Commands
@@ -59,7 +59,7 @@ PYTHONPATH=$PWD python3.11 tests/test_lead_research.py
 Optional local integration:
 
 ```bash
-CANNARADAR_RUN_FETCH_INTEGRATION=1 PYTHONPATH=$PWD python3.11 tests/test_fetch_integration.py
+PROVIDER_INTEL_RUN_FETCH_INTEGRATION=1 PYTHONPATH=$PWD python3.11 tests/test_fetch_integration.py
 ```
 
 CLI sanity checks:

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -10,6 +10,13 @@ from pathlib import Path
 DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "crawler_config.json"
 
 
+def _env_value(*names: str) -> str | None:
+    for name in names:
+        if name in os.environ:
+            return os.environ.get(name)
+    return None
+
+
 @dataclass
 class CrawlConfig:
     user_agent: str = "ABAProviderIntelligenceEngine/1.0 (+local; evidence-first)"
@@ -103,7 +110,7 @@ class CrawlConfig:
 
     def merged_denylist(self) -> set[str]:
         values = list(self.denylist)
-        env_denylist = os.environ.get("CANNARADAR_DENYLIST")
+        env_denylist = _env_value("PROVIDER_INTEL_DENYLIST", "CANNARADAR_DENYLIST")
         if env_denylist:
             values.extend([x.strip() for x in env_denylist.split(",")])
         return {str(v).strip().lower().lstrip(".") for v in values if str(v).strip()}
@@ -154,28 +161,38 @@ def _coerce_optional_int(value: object, default: int | None) -> int | None:
 
 def load_crawl_config(path: str | Path | None = None) -> CrawlConfig:
     defaults = CrawlConfig()
-    cfg_path = Path(path or os.environ.get("CANNARADAR_CRAWLER_CONFIG") or DEFAULT_CONFIG_PATH).resolve()
-    default_seed = os.environ.get("CANNARADAR_SEED_FILE", defaults.seed_file)
-    discovery_seed = os.environ.get("CANNARADAR_DISCOVERY_FILE", defaults.discovery_seed_file)
-    seed_failure_streak_limit = os.environ.get("CANNARADAR_SEED_FAILURE_STREAK_LIMIT")
-    seed_backoff_hours = os.environ.get("CANNARADAR_SEED_BACKOFF_HOURS")
-    weekly_new_lead_target = os.environ.get("CANNARADAR_WEEKLY_NEW_LEAD_TARGET")
-    growth_window_days = os.environ.get("CANNARADAR_GROWTH_WINDOW_DAYS")
-    enforce_growth_governor = os.environ.get("CANNARADAR_ENFORCE_GROWTH_GOVERNOR")
-    require_fetch_success_gate = os.environ.get("CANNARADAR_REQUIRE_FETCH_SUCCESS_GATE")
-    require_net_new_gate = os.environ.get("CANNARADAR_REQUIRE_NET_NEW_GATE")
-    fail_on_zero_new_leads = os.environ.get("CANNARADAR_FAIL_ON_ZERO_NEW_LEADS")
-    output_stale_hours = os.environ.get("CANNARADAR_OUTPUT_STALE_HOURS")
-    agent_research_enabled = os.environ.get("CANNARADAR_AGENT_RESEARCH")
-    agent_research_limit = os.environ.get("CANNARADAR_AGENT_RESEARCH_LIMIT")
-    agent_research_min_score = os.environ.get("CANNARADAR_AGENT_RESEARCH_MIN_SCORE")
-    retry_base_delay_seconds = os.environ.get("CANNARADAR_RETRY_BASE_DELAY_SECONDS")
-    retry_factor = os.environ.get("CANNARADAR_RETRY_FACTOR")
-    crawlee_headless = os.environ.get("CANNARADAR_CRAWLEE_HEADLESS")
-    crawlee_proxy_urls = os.environ.get("CANNARADAR_CRAWLEE_PROXY_URLS")
-    crawlee_max_browser_pages = os.environ.get("CANNARADAR_CRAWLEE_MAX_BROWSER_PAGES_PER_DOMAIN")
-    crawlee_browser_isolation = os.environ.get("CANNARADAR_CRAWLEE_BROWSER_ISOLATION")
-    crawlee_domain_policies_file = os.environ.get("CANNARADAR_CRAWLEE_DOMAIN_POLICIES_FILE")
+    cfg_path = Path(
+        path
+        or _env_value("PROVIDER_INTEL_CONFIG", "PROVIDER_INTEL_CRAWLER_CONFIG", "CANNARADAR_CRAWLER_CONFIG")
+        or DEFAULT_CONFIG_PATH
+    ).resolve()
+    default_seed = _env_value("PROVIDER_INTEL_SEED_FILE", "CANNARADAR_SEED_FILE") or defaults.seed_file
+    discovery_seed = _env_value("PROVIDER_INTEL_DISCOVERY_FILE", "CANNARADAR_DISCOVERY_FILE") or defaults.discovery_seed_file
+    seed_failure_streak_limit = _env_value("PROVIDER_INTEL_SEED_FAILURE_STREAK_LIMIT", "CANNARADAR_SEED_FAILURE_STREAK_LIMIT")
+    seed_backoff_hours = _env_value("PROVIDER_INTEL_SEED_BACKOFF_HOURS", "CANNARADAR_SEED_BACKOFF_HOURS")
+    weekly_new_lead_target = _env_value("PROVIDER_INTEL_WEEKLY_NEW_LEAD_TARGET", "CANNARADAR_WEEKLY_NEW_LEAD_TARGET")
+    growth_window_days = _env_value("PROVIDER_INTEL_GROWTH_WINDOW_DAYS", "CANNARADAR_GROWTH_WINDOW_DAYS")
+    enforce_growth_governor = _env_value("PROVIDER_INTEL_ENFORCE_GROWTH_GOVERNOR", "CANNARADAR_ENFORCE_GROWTH_GOVERNOR")
+    require_fetch_success_gate = _env_value("PROVIDER_INTEL_REQUIRE_FETCH_SUCCESS_GATE", "CANNARADAR_REQUIRE_FETCH_SUCCESS_GATE")
+    require_net_new_gate = _env_value("PROVIDER_INTEL_REQUIRE_NET_NEW_GATE", "CANNARADAR_REQUIRE_NET_NEW_GATE")
+    fail_on_zero_new_leads = _env_value("PROVIDER_INTEL_FAIL_ON_ZERO_NEW_LEADS", "CANNARADAR_FAIL_ON_ZERO_NEW_LEADS")
+    output_stale_hours = _env_value("PROVIDER_INTEL_OUTPUT_STALE_HOURS", "CANNARADAR_OUTPUT_STALE_HOURS")
+    agent_research_enabled = _env_value("PROVIDER_INTEL_AGENT_RESEARCH", "CANNARADAR_AGENT_RESEARCH")
+    agent_research_limit = _env_value("PROVIDER_INTEL_AGENT_RESEARCH_LIMIT", "CANNARADAR_AGENT_RESEARCH_LIMIT")
+    agent_research_min_score = _env_value("PROVIDER_INTEL_AGENT_RESEARCH_MIN_SCORE", "CANNARADAR_AGENT_RESEARCH_MIN_SCORE")
+    retry_base_delay_seconds = _env_value("PROVIDER_INTEL_RETRY_BASE_DELAY_SECONDS", "CANNARADAR_RETRY_BASE_DELAY_SECONDS")
+    retry_factor = _env_value("PROVIDER_INTEL_RETRY_FACTOR", "CANNARADAR_RETRY_FACTOR")
+    crawlee_headless = _env_value("PROVIDER_INTEL_CRAWLEE_HEADLESS", "CANNARADAR_CRAWLEE_HEADLESS")
+    crawlee_proxy_urls = _env_value("PROVIDER_INTEL_CRAWLEE_PROXY_URLS", "CANNARADAR_CRAWLEE_PROXY_URLS")
+    crawlee_max_browser_pages = _env_value(
+        "PROVIDER_INTEL_CRAWLEE_MAX_BROWSER_PAGES_PER_DOMAIN",
+        "CANNARADAR_CRAWLEE_MAX_BROWSER_PAGES_PER_DOMAIN",
+    )
+    crawlee_browser_isolation = _env_value("PROVIDER_INTEL_CRAWLEE_BROWSER_ISOLATION", "CANNARADAR_CRAWLEE_BROWSER_ISOLATION")
+    crawlee_domain_policies_file = _env_value(
+        "PROVIDER_INTEL_CRAWLEE_DOMAIN_POLICIES_FILE",
+        "CANNARADAR_CRAWLEE_DOMAIN_POLICIES_FILE",
+    )
 
     if not cfg_path.exists():
         return CrawlConfig(

--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -7,10 +7,25 @@ from typing import Optional
 from jobs.ingest_sources import init_db
 
 
-def connect_db(path: str | Path, schema_sql: str | Path | None = None) -> sqlite3.Connection:
+DEFAULT_DB_TIMEOUT_MS = 30000
+
+
+def normalized_db_timeout_ms(timeout_ms: int | None) -> int:
+    if timeout_ms is None:
+        return DEFAULT_DB_TIMEOUT_MS
+    return max(1, int(timeout_ms))
+
+
+def sqlite_timeout_seconds(timeout_ms: int | None) -> float:
+    return normalized_db_timeout_ms(timeout_ms) / 1000.0
+
+
+def connect_db(path: str | Path, schema_sql: str | Path | None = None, *, timeout_ms: int | None = None) -> sqlite3.Connection:
     db_path = Path(path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    con = sqlite3.connect(db_path)
+    effective_timeout_ms = normalized_db_timeout_ms(timeout_ms)
+    con = sqlite3.connect(db_path, timeout=sqlite_timeout_seconds(effective_timeout_ms))
+    con.execute(f"PRAGMA busy_timeout = {effective_timeout_ms}")
     con.execute("PRAGMA foreign_keys = ON")
     con.row_factory = sqlite3.Row
     if schema_sql:

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from jobs.ingest_sources import load_reference_rules
 from pipeline.config import load_crawl_config
@@ -26,16 +27,59 @@ MANIFEST_PATH = ROOT / "data" / "state" / "last_run_manifest.json"
 
 
 class PipelineRunner:
-    def __init__(self, seeds: str | None = None, max_pages: int | None = None, db_path: str | Path = DB_PATH):
+    def __init__(
+        self,
+        seeds: str | None = None,
+        max_pages: int | None = None,
+        db_path: str | Path = DB_PATH,
+        *,
+        db_timeout_ms: int | None = None,
+        config_overrides: dict[str, Any] | None = None,
+        crawl_mode: str = "full",
+    ):
         self.db_path = Path(db_path)
         self.max_pages = max_pages
+        self.db_timeout_ms = int(db_timeout_ms) if db_timeout_ms is not None else None
         self.config = load_crawl_config()
+        self.crawl_mode = str(crawl_mode or "full").strip().lower()
+        self._apply_config_overrides(config_overrides or {})
         self.seeds_path = str(seeds or self.config.seed_file or "seed_packs/nj/seed_pack.json")
         self.job_id = utcnow_iso().replace(":", "").replace("-", "").replace("T", "-")
         self.logger = build_logger(self.job_id, "provider_intel")
         self.metrics = Metrics(self.job_id)
         self._seed_lookup_cache: dict[str, DiscoverySeed] = {}
         self._metro_lookup_cache: dict[str, str] = {}
+
+    def _apply_config_overrides(self, overrides: dict[str, Any]) -> None:
+        for key, value in overrides.items():
+            if value is None or not hasattr(self.config, key):
+                continue
+            setattr(self.config, key, value)
+
+    def _fetch_mode_overrides(self) -> dict[str, int | None]:
+        if self.crawl_mode != "refresh":
+            return {
+                "max_pages_per_domain": None,
+                "max_total_pages": None,
+                "max_depth": None,
+            }
+
+        max_pages_per_domain = max(
+            1,
+            int(self.config.monitor_max_pages_per_domain or self.config.max_pages_per_domain or 1),
+        )
+        max_total_pages = int(self.config.monitor_max_total_pages or max_pages_per_domain)
+        if max_total_pages <= 0:
+            max_total_pages = max_pages_per_domain
+        max_depth = max(
+            0,
+            int(self.config.monitor_max_depth if self.config.monitor_max_depth is not None else self.config.max_depth),
+        )
+        return {
+            "max_pages_per_domain": max_pages_per_domain,
+            "max_total_pages": max_total_pages,
+            "max_depth": max_depth,
+        }
 
     def _seed_pack_path(self) -> Path:
         candidate = Path(self.seeds_path)
@@ -64,7 +108,7 @@ class PipelineRunner:
         return DiscoverySeed(name=name, website=website, state=state, market=market, source="seed_pack")
 
     def _load_results_for_extraction(self, since: str | None = None) -> list[FetchResult]:
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         query = """
             SELECT cj.crawl_job_pk, cj.seed_name, cj.seed_domain, cr.target_url, cr.status_code, cr.content,
                    cr.content_hash, cr.fetched_at
@@ -100,7 +144,7 @@ class PipelineRunner:
         return fetched
 
     def run_seed_ingest(self, seed_limit: int | None = None) -> dict[str, object]:
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         for table in (
             "providers",
             "practices",
@@ -135,7 +179,11 @@ class PipelineRunner:
         run_state_dir: str | Path | None = None,
     ) -> list[FetchResult]:
         seeds = seeds or self._load_seeds()
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
+        mode_overrides = self._fetch_mode_overrides()
+        effective_max_pages = max_pages_per_domain if max_pages_per_domain is not None else mode_overrides["max_pages_per_domain"]
+        effective_max_total = max_total_pages if max_total_pages is not None else mode_overrides["max_total_pages"]
+        effective_max_depth = max_depth if max_depth is not None else mode_overrides["max_depth"]
         fetched = run_fetch(
             con=con,
             seeds=seeds,
@@ -143,9 +191,9 @@ class PipelineRunner:
             logger=self.logger,
             metrics=self.metrics,
             job_id=self.job_id,
-            max_pages_per_domain=max_pages_per_domain,
-            max_total_pages=max_total_pages,
-            max_depth=max_depth,
+            max_pages_per_domain=effective_max_pages,
+            max_total_pages=effective_max_total,
+            max_depth=effective_max_depth,
             run_state_dir=run_state_dir,
         )
         con.close()
@@ -153,7 +201,7 @@ class PipelineRunner:
 
     def run_extract(self, fetched: list[FetchResult] | None = None, since: str | None = None) -> int:
         fetched_rows = list(fetched or self._load_results_for_extraction(since))
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         metro_lookup = self._load_metro_lookup()
         extracted_count = 0
         for item in fetched_rows:
@@ -231,7 +279,7 @@ class PipelineRunner:
         return extracted_count
 
     def run_resolve(self) -> dict[str, int]:
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         result = resolve_extracted_records(con)
         con.close()
         return {
@@ -240,19 +288,19 @@ class PipelineRunner:
         }
 
     def run_score(self) -> int:
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         updated = run_score(con)
         con.close()
         return updated
 
     def run_qa(self) -> dict[str, int]:
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         result = run_qa(con)
         con.close()
         return result
 
     def run_export(self, limit: int = 100) -> dict[str, object]:
-        con = connect_db(self.db_path, SCHEMA_PATH)
+        con = connect_db(self.db_path, SCHEMA_PATH, timeout_ms=self.db_timeout_ms)
         result = export_provider_intel(con, OUT_DIR, self.job_id, limit=limit)
         con.close()
         return result

--- a/tests/test_fetch_config.py
+++ b/tests/test_fetch_config.py
@@ -66,13 +66,13 @@ def test_env_overrides_apply_to_crawlee_settings() -> None:
         )
 
         previous = _set_env(
-            CANNARADAR_CRAWLEE_HEADLESS="off",
-            CANNARADAR_CRAWLEE_PROXY_URLS="http://env-proxy-1:8080,http://env-proxy-2:8080",
-            CANNARADAR_CRAWLEE_MAX_BROWSER_PAGES_PER_DOMAIN="9",
-            CANNARADAR_CRAWLEE_DOMAIN_POLICIES_FILE="ops/custom_policies.json",
-            CANNARADAR_AGENT_RESEARCH="on",
-            CANNARADAR_AGENT_RESEARCH_LIMIT="7",
-            CANNARADAR_AGENT_RESEARCH_MIN_SCORE="62",
+            PROVIDER_INTEL_CRAWLEE_HEADLESS="off",
+            PROVIDER_INTEL_CRAWLEE_PROXY_URLS="http://env-proxy-1:8080,http://env-proxy-2:8080",
+            PROVIDER_INTEL_CRAWLEE_MAX_BROWSER_PAGES_PER_DOMAIN="9",
+            PROVIDER_INTEL_CRAWLEE_DOMAIN_POLICIES_FILE="ops/custom_policies.json",
+            PROVIDER_INTEL_AGENT_RESEARCH="on",
+            PROVIDER_INTEL_AGENT_RESEARCH_LIMIT="7",
+            PROVIDER_INTEL_AGENT_RESEARCH_MIN_SCORE="62",
         )
         try:
             cfg = load_crawl_config(config_path)
@@ -92,9 +92,26 @@ def test_env_overrides_apply_to_crawlee_settings() -> None:
         assert cfg.agent_research_min_score == 62
 
 
+def test_legacy_cannaradar_env_alias_still_works() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        config_path = Path(td) / "crawler_config.json"
+        config_path.write_text(json.dumps({"seedFile": "seed_packs/nj/seed_pack.json"}), encoding="utf-8")
+        previous = _set_env(
+            PROVIDER_INTEL_CRAWLEE_HEADLESS=None,
+            CANNARADAR_CRAWLEE_HEADLESS="off",
+        )
+        try:
+            cfg = load_crawl_config(config_path)
+        finally:
+            _restore_env(previous)
+
+        assert cfg.crawlee_headless is False
+
+
 def main() -> None:
     test_load_crawl_config_defaults_include_crawlee_settings()
     test_env_overrides_apply_to_crawlee_settings()
+    test_legacy_cannaradar_env_alias_still_works()
     print("test_fetch_config: ok")
 
 

--- a/tests/test_fetch_dispatch.py
+++ b/tests/test_fetch_dispatch.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import tempfile
 from pathlib import Path
 
 from pipeline.config import load_crawl_config
+from pipeline.db import connect_db
 import pipeline.fetch_backends.crawlee_backend as crawlee_backend
+import pipeline.pipeline as pipeline_module
 from pipeline.fetch_backends.crawlee_backend import SeedCrawlState
 from pipeline.fetch_backends.common import (
     SeedRunRecorder,
@@ -17,6 +20,7 @@ from pipeline.fetch_backends.common import (
 )
 from pipeline.fetch_backends.domain_policy import load_domain_policies
 from pipeline.observability import Metrics, build_logger
+from pipeline.pipeline import PipelineRunner
 from pipeline.run_control import load_run_control
 from pipeline.stages.discovery import DiscoverySeed
 
@@ -267,6 +271,96 @@ def test_seed_run_recorder_commits_progress_immediately() -> None:
         con.close()
 
 
+def test_connect_db_applies_busy_timeout() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "busy-timeout.db"
+        con = connect_db(db_path, timeout_ms=4321)
+        timeout_value = int(con.execute("PRAGMA busy_timeout").fetchone()[0])
+        con.close()
+        assert timeout_value == 4321
+
+
+def test_pipeline_runner_refresh_mode_uses_monitor_fetch_limits() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        config_path = root / "crawler_config.json"
+        db_path = root / "provider_intel.db"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "seedFile": "seed_packs/nj/seed_pack.json",
+                    "monitorMaxPagesPerDomain": 4,
+                    "monitorMaxTotalPages": 3,
+                    "monitorMaxDepth": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        previous = os.environ.get("PROVIDER_INTEL_CONFIG")
+        os.environ["PROVIDER_INTEL_CONFIG"] = str(config_path)
+        original_run_fetch = pipeline_module.run_fetch
+        captured: dict[str, object] = {}
+        try:
+            def fake_run_fetch(**kwargs):
+                captured.update(
+                    {
+                        "max_pages_per_domain": kwargs.get("max_pages_per_domain"),
+                        "max_total_pages": kwargs.get("max_total_pages"),
+                        "max_depth": kwargs.get("max_depth"),
+                    }
+                )
+                return []
+
+            pipeline_module.run_fetch = fake_run_fetch
+            runner = PipelineRunner(db_path=db_path, crawl_mode="refresh")
+            runner.run_fetch(
+                seeds=[DiscoverySeed(name="Demo", website="https://demo.example", state="NJ", market="Newark")],
+            )
+        finally:
+            pipeline_module.run_fetch = original_run_fetch
+            if previous is None:
+                os.environ.pop("PROVIDER_INTEL_CONFIG", None)
+            else:
+                os.environ["PROVIDER_INTEL_CONFIG"] = previous
+
+        assert captured == {
+            "max_pages_per_domain": 4,
+            "max_total_pages": 3,
+            "max_depth": 1,
+        }
+
+
+def test_pipeline_runner_applies_headless_override() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        config_path = root / "crawler_config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "seedFile": "seed_packs/nj/seed_pack.json",
+                    "crawleeHeadless": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        previous = os.environ.get("PROVIDER_INTEL_CONFIG")
+        os.environ["PROVIDER_INTEL_CONFIG"] = str(config_path)
+        try:
+            runner = PipelineRunner(
+                db_path=root / "provider_intel.db",
+                config_overrides={"crawlee_headless": False},
+            )
+        finally:
+            if previous is None:
+                os.environ.pop("PROVIDER_INTEL_CONFIG", None)
+            else:
+                os.environ["PROVIDER_INTEL_CONFIG"] = previous
+
+        assert runner.config.crawlee_headless is False
+
+
 def test_seed_crawl_state_filters_assets_and_honors_manual_controls() -> None:
     con = _connect()
     metrics = Metrics("fetch-controls")
@@ -460,6 +554,9 @@ def main() -> None:
     test_seed_run_recorder_persists_contract_rows_and_results()
     test_seed_run_recorder_uses_status_hint_for_empty_blocked_seed()
     test_seed_run_recorder_commits_progress_immediately()
+    test_connect_db_applies_busy_timeout()
+    test_pipeline_runner_refresh_mode_uses_monitor_fetch_limits()
+    test_pipeline_runner_applies_headless_override()
     test_seed_crawl_state_filters_assets_and_honors_manual_controls()
     test_seed_crawl_state_auto_suppresses_prefix_and_stops_on_dns()
     test_run_fetch_contains_browser_driver_failure_to_one_seed()

--- a/tests/test_fetch_integration.py
+++ b/tests/test_fetch_integration.py
@@ -127,8 +127,12 @@ def _write_config(base: Path, *, port: int, browser_mode: bool = False) -> Path:
 
 
 def test_fetch_integration_local_server() -> None:
-    if os.environ.get("CANNARADAR_RUN_FETCH_INTEGRATION") != "1":
-        print("test_fetch_integration: skipped (set CANNARADAR_RUN_FETCH_INTEGRATION=1)")
+    run_fetch_integration = (
+        os.environ.get("PROVIDER_INTEL_RUN_FETCH_INTEGRATION")
+        or os.environ.get("CANNARADAR_RUN_FETCH_INTEGRATION")
+    )
+    if run_fetch_integration != "1":
+        print("test_fetch_integration: skipped (set PROVIDER_INTEL_RUN_FETCH_INTEGRATION=1)")
         return
 
     from pipeline.stages.fetch import run_fetch

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -14,14 +14,20 @@ from pipeline.fetch_backends.common import FetchResult
 
 class FakeRunner:
     should_fail_once = True
+    last_init: dict[str, object] = {}
 
-    def __init__(self, seeds=None, db_path=None):
+    def __init__(self, seeds=None, db_path=None, **kwargs):
         self.seeds_path = seeds or "seed_packs/nj/seed_pack.json"
         self.db_path = Path(db_path)
         self.job_id = "fake-job"
         self.config = SimpleNamespace(config_path=str(self.db_path.parent / "crawler_config.json"))
         self.metrics = SimpleNamespace(snapshot=lambda: {})
         self._seeds = [DiscoverySeed(name="NJ Seed", website="https://seed.example", state="NJ", market="Newark", tier="A", source_type="licensing_board", extraction_profile="board")]
+        FakeRunner.last_init = {
+            "seeds": self.seeds_path,
+            "db_path": str(self.db_path),
+            **kwargs,
+        }
 
     def _load_seeds(self, seed_limit=None):
         return self._seeds[: seed_limit or len(self._seeds)]
@@ -92,6 +98,7 @@ def test_run_state_round_trip() -> None:
 
 def test_execute_sync_can_resume_from_checkpoint() -> None:
     FakeRunner.should_fail_once = True
+    FakeRunner.last_init = {}
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         checkpoint_dir = root / "checkpoints"
@@ -101,11 +108,12 @@ def test_execute_sync_can_resume_from_checkpoint() -> None:
             max=1,
             crawl_mode="full",
             limit=100,
-            crawlee_headless=None,
+            crawlee_headless="off",
             run_id="resume-test",
             resume=None,
             checkpoint_dir=str(checkpoint_dir),
             config=None,
+            db_timeout_ms=12345,
         )
 
         try:
@@ -113,6 +121,10 @@ def test_execute_sync_can_resume_from_checkpoint() -> None:
             raise AssertionError("sync should have failed on the first extract attempt")
         except RuntimeError as exc:
             assert "synthetic extract failure" in str(exc)
+
+        assert FakeRunner.last_init["db_timeout_ms"] == 12345
+        assert FakeRunner.last_init["crawl_mode"] == "full"
+        assert FakeRunner.last_init["config_overrides"] == {"crawlee_headless": False}
 
         state = load_run_state("resume-test", checkpoint_dir)
         assert state["stages"]["extract"]["status"] == "failed"
@@ -124,6 +136,32 @@ def test_execute_sync_can_resume_from_checkpoint() -> None:
         assert resumed["status"] == "completed"
         assert resumed["stages"]["qa"]["status"] == "completed"
         assert resumed["stages"]["export"]["status"] == "completed"
+
+
+def test_execute_sync_passes_refresh_mode_to_runner() -> None:
+    FakeRunner.last_init = {}
+    FakeRunner.should_fail_once = False
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        checkpoint_dir = root / "checkpoints"
+        args = SimpleNamespace(
+            db=str(root / "provider_intel.db"),
+            seeds="seed_packs/nj/seed_pack.json",
+            max=1,
+            crawl_mode="refresh",
+            limit=25,
+            crawlee_headless=None,
+            run_id="refresh-test",
+            resume=None,
+            checkpoint_dir=str(checkpoint_dir),
+            config=None,
+            db_timeout_ms=5000,
+        )
+
+        execute_sync(args, runner_factory=FakeRunner)
+
+        assert FakeRunner.last_init["crawl_mode"] == "refresh"
+        assert FakeRunner.last_init["db_timeout_ms"] == 5000
 
 
 def test_finalize_run_control_clears_stale_running_domain() -> None:
@@ -153,6 +191,7 @@ def test_finalize_run_control_clears_stale_running_domain() -> None:
 def main() -> None:
     test_run_state_round_trip()
     test_execute_sync_can_resume_from_checkpoint()
+    test_execute_sync_passes_refresh_mode_to_runner()
     test_finalize_run_control_clears_stale_running_domain()
     print("test_run_state: ok")
 


### PR DESCRIPTION
Wire refresh crawl mode, headless override, and db timeout into the active CLI/runtime so the agent contract matches shipped behavior.

Prefer PROVIDER_INTEL_* env names in docs and config loading while keeping legacy CANNARADAR_* aliases for compatibility.

Rollback hint: revert this commit to restore the prior metadata-only flag behavior and legacy env/docs surface.